### PR TITLE
fix: prevent double-wrapping of wikilink project references

### DIFF
--- a/src/mapper.ts
+++ b/src/mapper.ts
@@ -20,9 +20,7 @@ export function mapToFrontmatter(parsed: ParsedTaskData): {
   if (parsed.tags && parsed.tags.length > 0) fm.tags = parsed.tags;
   if (parsed.contexts && parsed.contexts.length > 0) fm.contexts = parsed.contexts;
   if (parsed.projects && parsed.projects.length > 0) {
-    fm.projects = parsed.projects.map((p) =>
-      p.startsWith('[[') && p.endsWith(']]') ? p : `[[projects/${p}]]`
-    );
+    fm.projects = parsed.projects.map(toProjectWikilink);
   }
   if (parsed.recurrence) fm.recurrence = parsed.recurrence;
   if (parsed.estimate) fm.timeEstimate = parsed.estimate;
@@ -30,6 +28,15 @@ export function mapToFrontmatter(parsed: ParsedTaskData): {
   const body = parsed.details || undefined;
 
   return { frontmatter: fm, body };
+}
+
+function toProjectWikilink(project: string): string {
+  const trimmed = project.trim();
+  return isWikilink(trimmed) ? trimmed : `[[projects/${trimmed}]]`;
+}
+
+function isWikilink(value: string): boolean {
+  return /^\[\[[^\]]+\]\]$/.test(value);
 }
 
 /**

--- a/src/mapper.ts
+++ b/src/mapper.ts
@@ -20,7 +20,9 @@ export function mapToFrontmatter(parsed: ParsedTaskData): {
   if (parsed.tags && parsed.tags.length > 0) fm.tags = parsed.tags;
   if (parsed.contexts && parsed.contexts.length > 0) fm.contexts = parsed.contexts;
   if (parsed.projects && parsed.projects.length > 0) {
-    fm.projects = parsed.projects.map((p) => `[[projects/${p}]]`);
+    fm.projects = parsed.projects.map((p) =>
+      p.startsWith('[[') && p.endsWith(']]') ? p : `[[projects/${p}]]`
+    );
   }
   if (parsed.recurrence) fm.recurrence = parsed.recurrence;
   if (parsed.estimate) fm.timeEstimate = parsed.estimate;

--- a/tests/mapper-wikilink.test.mjs
+++ b/tests/mapper-wikilink.test.mjs
@@ -1,30 +1,41 @@
-import test from 'node:test';
-import assert from 'node:assert/strict';
-import { mapToFrontmatter } from '../dist/mapper.js';
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mapToFrontmatter } from "../dist/mapper.js";
 
-test('mapToFrontmatter wraps plain project names as wikilinks', () => {
+test("mapToFrontmatter wraps plain project names as wikilinks", () => {
   const { frontmatter } = mapToFrontmatter({
-    title: 'Test task',
-    projects: ['simple'],
+    title: "Test task",
+    projects: ["simple"],
   });
-  assert.deepEqual(frontmatter.projects, ['[[projects/simple]]']);
+  assert.deepEqual(frontmatter.projects, ["[[projects/simple]]"]);
 });
 
-test('mapToFrontmatter preserves projects already in wikilink syntax', () => {
+test("mapToFrontmatter preserves projects already in wikilink syntax", () => {
   const { frontmatter } = mapToFrontmatter({
-    title: 'Test task',
-    projects: ['[[projecten/Bente Commercial]]'],
+    title: "Test task",
+    projects: ["[[projecten/Bente Commercial]]"],
   });
-  assert.deepEqual(frontmatter.projects, ['[[projecten/Bente Commercial]]']);
+  assert.deepEqual(frontmatter.projects, ["[[projecten/Bente Commercial]]"]);
 });
 
-test('mapToFrontmatter handles mixed plain and wikilink projects', () => {
+test("mapToFrontmatter handles mixed plain and wikilink projects", () => {
   const { frontmatter } = mapToFrontmatter({
-    title: 'Test task',
-    projects: ['simple', '[[projecten/Bente Commercial]]'],
+    title: "Test task",
+    projects: ["simple", "[[projecten/Bente Commercial]]"],
   });
   assert.deepEqual(frontmatter.projects, [
-    '[[projects/simple]]',
-    '[[projecten/Bente Commercial]]',
+    "[[projects/simple]]",
+    "[[projecten/Bente Commercial]]",
+  ]);
+});
+
+test("mapToFrontmatter trims project values before wrapping or preserving wikilinks", () => {
+  const { frontmatter } = mapToFrontmatter({
+    title: "Test task",
+    projects: [" simple ", " [[projecten/Bente Commercial]] "],
+  });
+  assert.deepEqual(frontmatter.projects, [
+    "[[projects/simple]]",
+    "[[projecten/Bente Commercial]]",
   ]);
 });

--- a/tests/mapper-wikilink.test.mjs
+++ b/tests/mapper-wikilink.test.mjs
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mapToFrontmatter } from '../dist/mapper.js';
+
+test('mapToFrontmatter wraps plain project names as wikilinks', () => {
+  const { frontmatter } = mapToFrontmatter({
+    title: 'Test task',
+    projects: ['simple'],
+  });
+  assert.deepEqual(frontmatter.projects, ['[[projects/simple]]']);
+});
+
+test('mapToFrontmatter preserves projects already in wikilink syntax', () => {
+  const { frontmatter } = mapToFrontmatter({
+    title: 'Test task',
+    projects: ['[[projecten/Bente Commercial]]'],
+  });
+  assert.deepEqual(frontmatter.projects, ['[[projecten/Bente Commercial]]']);
+});
+
+test('mapToFrontmatter handles mixed plain and wikilink projects', () => {
+  const { frontmatter } = mapToFrontmatter({
+    title: 'Test task',
+    projects: ['simple', '[[projecten/Bente Commercial]]'],
+  });
+  assert.deepEqual(frontmatter.projects, [
+    '[[projects/simple]]',
+    '[[projecten/Bente Commercial]]',
+  ]);
+});


### PR DESCRIPTION
## Problem

When users pass projects already in wikilink syntax via the `+` prefix (e.g. `+[[projecten/Bente Commercial]]`), `mapToFrontmatter` wraps them again, producing malformed frontmatter:

```yaml
projects:
  - "[[projects/[[projecten/Bente Commercial]]]]"
```

This happens because the mapper unconditionally wraps all project strings in `[[projects/...]]` without checking if they're already wikilinks.

## Fix

Check whether a project string already has wikilink syntax before wrapping:

```ts
fm.projects = parsed.projects.map((p) =>
  p.startsWith('[[') && p.endsWith(']]') ? p : `[[projects/${p}]]`
);
```

Plain project names (e.g. `+simple`) continue to be wrapped as `[[projects/simple]]` — existing behavior is preserved.

## Why this matters

This also provides a workaround for the hardcoded `projects/` prefix. Users with non-English vaults (e.g. Dutch `projecten/`) can now pass fully-qualified wikilinks and have them preserved as-is, rather than getting incorrect English paths.

A configurable `projectsPrefix` option would be a cleaner long-term solution — happy to add that in this PR or a follow-up if you'd prefer.

## Test plan

- [x] Added unit tests in `tests/mapper-wikilink.test.mjs` covering:
  - Plain project names are wrapped (existing behavior)
  - Wikilink projects are preserved as-is
  - Mixed plain + wikilink projects handled correctly
- [x] All existing tests still pass (1008 pass, 4 pre-existing failures)

### Note on pre-existing test failures

The 4 failing tests are all in `tests/conformance/config-provider.conformance.test.mjs` and are unrelated to this change (same failures on `main`). They're caused by a macOS symlink issue: `mkdtempSync(os.tmpdir())` returns `/var/folders/...` but after `process.chdir()`, `process.cwd()` resolves the symlink to `/private/var/folders/...`, causing string comparison mismatches. Wrapping the temp dir creation with `realpathSync` would fix it:

```js
const cwdA = realpathSync(mkdtempSync(join(tmpdir(), "mtn-cwd-a-")));
const cwdB = realpathSync(mkdtempSync(join(tmpdir(), "mtn-cwd-b-")));
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)