### PR TITLE
ci: publish npm releases with trusted publishing

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,59 @@
+name: Publish npm package
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: npm
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+      - run: npm install --global npm@11
+
+      - name: Validate tag
+        id: release
+        run: |
+          VERSION="$(node --print "require('./package.json').version")"
+          if [ "$GITHUB_REF_NAME" != "v${VERSION}" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME does not match package version v${VERSION}"
+            exit 1
+          fi
+          case "$VERSION" in
+            *-*) DIST_TAG="next" ;;
+            *) DIST_TAG="latest" ;;
+          esac
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "dist_tag=$DIST_TAG" >> "$GITHUB_OUTPUT"
+
+      - run: npm ci
+      - run: npm test
+      - run: npm run test:package
+
+      - name: Confirm version is unpublished
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          if npm view "mdbase-tasknotes@$VERSION" version >/dev/null 2>&1; then
+            echo "::error::mdbase-tasknotes@$VERSION is already published"
+            exit 1
+          fi
+
+      - name: Publish package
+        env:
+          DIST_TAG: ${{ steps.release.outputs.dist_tag }}
+        run: npm publish --access public --tag "$DIST_TAG"


### PR DESCRIPTION
## Summary
- publish version tags through GitHub Actions and npm Trusted Publishing
- validate tag/package version alignment
- preserve prerelease and stable npm dist-tags

## Verification
- `npm test` (1,041 tests)
- `npm run test:package`
- `npm pack --dry-run`
- actionlint