### PR TITLE
Exact-task timer stop and schema-aware field updates, plus a Windows exit-code fix

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -176,11 +176,11 @@ timer
   });
 
 timer
-  .command("stop")
+  .command("stop [pathOrTitle]")
   .description("Stop the running timer")
-  .action(() => {
+  .action((pathOrTitle?: string) => {
     const parentOpts = program.opts();
-    return timerStopCommand({ path: parentOpts.path });
+    return timerStopCommand({ path: parentOpts.path, pathOrTitle });
   });
 
 timer

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -99,6 +99,7 @@ program
   .option("--remove-tag <tag>", "Remove a tag", collect, [])
   .option("--add-context <ctx>", "Add a context", collect, [])
   .option("--remove-context <ctx>", "Remove a context", collect, [])
+  .option("--set <field=value>", "Set an existing schema field", collect, [])
   .action((pathOrTitle: string, opts: any) => {
     const parentOpts = program.opts();
     return updateCommand(pathOrTitle, {
@@ -108,6 +109,7 @@ program
       removeTag: opts.removeTag?.length ? opts.removeTag : undefined,
       addContext: opts.addContext?.length ? opts.addContext : undefined,
       removeContext: opts.removeContext?.length ? opts.removeContext : undefined,
+      set: opts.set?.length ? opts.set : undefined,
     });
   });
 

--- a/src/commands/archive.ts
+++ b/src/commands/archive.ts
@@ -12,8 +12,7 @@ export async function archiveCommand(
       const read = await collection.read(taskPath);
 
       if (read.error) {
-        showError(`Failed to read task: ${read.error.message}`);
-        process.exit(1);
+        throw new Error(`Failed to read task: ${read.error.message}`);
       }
 
       const fm = normalizeFrontmatter(read.frontmatter as Record<string, unknown>, mapping);
@@ -33,14 +32,15 @@ export async function archiveCommand(
       });
 
       if (result.error) {
-        showError(`Failed to archive task: ${result.error.message}`);
-        process.exit(1);
+        throw new Error(`Failed to archive task: ${result.error.message}`);
       }
 
       showSuccess(`Archived: ${taskTitle}`);
     }, options.path);
   } catch (err) {
     showError((err as Error).message);
-    process.exit(1);
+    // process.exit aqui abortava no Windows (UV_HANDLE_CLOSING) porque a colecao
+    // ainda estava fechando; exitCode deixa o loop drenar e sair com 1 de verdade.
+    process.exitCode = 1;
   }
 }

--- a/src/commands/complete.ts
+++ b/src/commands/complete.ts
@@ -20,8 +20,7 @@ export async function completeCommand(
       const read = await collection.read(taskPath);
 
       if (read.error) {
-        showError(`Failed to read task: ${read.error.message}`);
-        process.exit(1);
+        throw new Error(`Failed to read task: ${read.error.message}`);
       }
 
       const fm = normalizeFrontmatter(read.frontmatter as Record<string, unknown>, mapping);
@@ -61,8 +60,7 @@ export async function completeCommand(
           });
 
           if (result.error) {
-            showError(`Failed to complete task: ${result.error.message}`);
-            process.exit(1);
+            throw new Error(`Failed to complete task: ${result.error.message}`);
           }
 
           showSuccess(`Completed: ${taskTitle}`);
@@ -75,8 +73,7 @@ export async function completeCommand(
         });
 
         if (result.error) {
-          showError(`Failed to complete recurring task: ${result.error.message}`);
-          process.exit(1);
+          throw new Error(`Failed to complete recurring task: ${result.error.message}`);
         }
 
         showSuccess(`Completed recurring instance: ${taskTitle} → next ${nextScheduled}`);
@@ -97,14 +94,15 @@ export async function completeCommand(
       });
 
       if (result.error) {
-        showError(`Failed to complete task: ${result.error.message}`);
-        process.exit(1);
+        throw new Error(`Failed to complete task: ${result.error.message}`);
       }
 
       showSuccess(`Completed: ${taskTitle}`);
     }, options.path);
   } catch (err) {
     showError((err as Error).message);
-    process.exit(1);
+    // process.exit aqui abortava no Windows (UV_HANDLE_CLOSING) porque a colecao
+    // ainda estava fechando; exitCode deixa o loop drenar e sair com 1 de verdade.
+    process.exitCode = 1;
   }
 }

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -37,8 +37,7 @@ export async function createCommand(
       }
 
       if (result.error) {
-        showError(`Failed to create task: ${result.error.message}`);
-        process.exit(1);
+        throw new Error(`Failed to create task: ${result.error.message}`);
       }
 
       const fm = normalizeFrontmatter(result.frontmatter as Record<string, unknown>, mapping);
@@ -54,6 +53,8 @@ export async function createCommand(
     }, options.path);
   } catch (err) {
     showError((err as Error).message);
-    process.exit(1);
+    // process.exit aqui abortava no Windows (UV_HANDLE_CLOSING) porque a colecao
+    // ainda estava fechando; exitCode deixa o loop drenar e sair com 1 de verdade.
+    process.exitCode = 1;
   }
 }

--- a/src/commands/delete.ts
+++ b/src/commands/delete.ts
@@ -18,13 +18,11 @@ export async function deleteCommand(
           for (const link of result.broken_links) {
             console.log(`  - ${link.path}`);
           }
-          showError("Use --force to delete anyway.");
-          process.exit(1);
+          throw new Error("Use --force to delete anyway.");
         }
 
         if (result.error) {
-          showError(`Failed to delete task: ${result.error.message}`);
-          process.exit(1);
+          throw new Error(`Failed to delete task: ${result.error.message}`);
         }
 
         showSuccess(`Deleted: ${taskPath}`);
@@ -32,8 +30,7 @@ export async function deleteCommand(
         const result = await collection.delete(taskPath);
 
         if (result.error) {
-          showError(`Failed to delete task: ${result.error.message}`);
-          process.exit(1);
+          throw new Error(`Failed to delete task: ${result.error.message}`);
         }
 
         showSuccess(`Deleted: ${taskPath}`);
@@ -41,6 +38,8 @@ export async function deleteCommand(
     }, options.path);
   } catch (err) {
     showError((err as Error).message);
-    process.exit(1);
+    // process.exit aqui abortava no Windows (UV_HANDLE_CLOSING) porque a colecao
+    // ainda estava fechando; exitCode deixa o loop drenar e sair com 1 de verdade.
+    process.exitCode = 1;
   }
 }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -20,6 +20,8 @@ export async function initCommand(
     console.log(`Create tasks with: ${chalk.cyan("mtn create \"Buy groceries tomorrow #shopping\"")}`);
   } catch (err) {
     console.error(chalk.red("✗") + ` ${(err as Error).message}`);
-    process.exit(1);
+    // process.exit aqui abortava no Windows (UV_HANDLE_CLOSING) porque a colecao
+    // ainda estava fechando; exitCode deixa o loop drenar e sair com 1 de verdade.
+    process.exitCode = 1;
   }
 }

--- a/src/commands/interactive.ts
+++ b/src/commands/interactive.ts
@@ -107,7 +107,7 @@ export async function interactiveCommand(
           }
 
           if (result.error) {
-            showError(`Failed to create task: ${result.error.message}`);
+            throw new Error(`Failed to create task: ${result.error.message}`);
           } else {
             const fm = normalizeFrontmatter(result.frontmatter as Record<string, unknown>, mapping);
             const task: TaskResult = {
@@ -173,6 +173,5 @@ export async function interactiveCommand(
     }, options.path);
   } catch (err) {
     showError((err as Error).message);
-    process.exit(1);
   }
 }

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -174,6 +174,8 @@ export async function listCommand(options: {
     }, options.path);
   } catch (err) {
     showError((err as Error).message);
-    process.exit(1);
+    // process.exit aqui abortava no Windows (UV_HANDLE_CLOSING) porque a colecao
+    // ainda estava fechando; exitCode deixa o loop drenar e sair com 1 de verdade.
+    process.exitCode = 1;
   }
 }

--- a/src/commands/projects.ts
+++ b/src/commands/projects.ts
@@ -227,7 +227,9 @@ export async function projectsListCommand(
     }, options.path);
   } catch (err) {
     showError((err as Error).message);
-    process.exit(1);
+    // process.exit aqui abortava no Windows (UV_HANDLE_CLOSING) porque a colecao
+    // ainda estava fechando; exitCode deixa o loop drenar e sair com 1 de verdade.
+    process.exitCode = 1;
   }
 }
 
@@ -286,6 +288,8 @@ export async function projectsShowCommand(
     }, options.path);
   } catch (err) {
     showError((err as Error).message);
-    process.exit(1);
+    // process.exit aqui abortava no Windows (UV_HANDLE_CLOSING) porque a colecao
+    // ainda estava fechando; exitCode deixa o loop drenar e sair com 1 de verdade.
+    process.exitCode = 1;
   }
 }

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -74,6 +74,8 @@ export async function searchCommand(
     }, options.path);
   } catch (err) {
     showError((err as Error).message);
-    process.exit(1);
+    // process.exit aqui abortava no Windows (UV_HANDLE_CLOSING) porque a colecao
+    // ainda estava fechando; exitCode deixa o loop drenar e sair com 1 de verdade.
+    process.exitCode = 1;
   }
 }

--- a/src/commands/show.ts
+++ b/src/commands/show.ts
@@ -15,8 +15,7 @@ export async function showCommand(
       const result = await collection.read(taskPath);
 
       if (result.error) {
-        showError(`Failed to read task: ${result.error.message}`);
-        process.exit(1);
+        throw new Error(`Failed to read task: ${result.error.message}`);
       }
 
       const fm = normalizeFrontmatter(result.frontmatter as Record<string, unknown>, mapping);
@@ -35,6 +34,8 @@ export async function showCommand(
     }, options.path);
   } catch (err) {
     showError((err as Error).message);
-    process.exit(1);
+    // process.exit aqui abortava no Windows (UV_HANDLE_CLOSING) porque a colecao
+    // ainda estava fechando; exitCode deixa o loop drenar e sair com 1 de verdade.
+    process.exitCode = 1;
   }
 }

--- a/src/commands/skip.ts
+++ b/src/commands/skip.ts
@@ -28,15 +28,13 @@ async function setSkipState(
       const read = await collection.read(taskPath);
 
       if (read.error) {
-        showError(`Failed to read task: ${read.error.message}`);
-        process.exit(1);
+        throw new Error(`Failed to read task: ${read.error.message}`);
       }
 
       const fm = normalizeFrontmatter(read.frontmatter as Record<string, unknown>, mapping);
       const taskTitle = resolveDisplayTitle(fm, mapping, taskPath) || taskPath;
       if (typeof fm.recurrence !== "string" || fm.recurrence.trim().length === 0) {
-        showError("Skip/unskip is only supported for recurring tasks.");
-        process.exit(1);
+        throw new Error("Skip/unskip is only supported for recurring tasks.");
       }
 
       const targetDate = resolveOperationTargetDate(
@@ -63,8 +61,7 @@ async function setSkipState(
       });
 
       if (result.error) {
-        showError(`Failed to ${options.skip ? "skip" : "unskip"} recurring instance: ${result.error.message}`);
-        process.exit(1);
+        throw new Error(`Failed to ${options.skip ? "skip" : "unskip"} recurring instance: ${result.error.message}`);
       }
 
       const verb = options.skip ? "Skipped" : "Unskipped";
@@ -76,6 +73,8 @@ async function setSkipState(
     }, options.path);
   } catch (err) {
     showError((err as Error).message);
-    process.exit(1);
+    // process.exit aqui abortava no Windows (UV_HANDLE_CLOSING) porque a colecao
+    // ainda estava fechando; exitCode deixa o loop drenar e sair com 1 de verdade.
+    process.exitCode = 1;
   }
 }

--- a/src/commands/stats.ts
+++ b/src/commands/stats.ts
@@ -88,6 +88,8 @@ export async function statsCommand(
     }, options.path);
   } catch (err) {
     showError((err as Error).message);
-    process.exit(1);
+    // process.exit aqui abortava no Windows (UV_HANDLE_CLOSING) porque a colecao
+    // ainda estava fechando; exitCode deixa o loop drenar e sair com 1 de verdade.
+    process.exitCode = 1;
   }
 }

--- a/src/commands/timer.ts
+++ b/src/commands/timer.ts
@@ -62,10 +62,23 @@ export async function timerStartCommand(
 }
 
 export async function timerStopCommand(
-  options: { path?: string },
+  options: { path?: string; pathOrTitle?: string },
 ): Promise<void> {
   try {
     await withCollection(async (collection, mapping) => {
+      if (options.pathOrTitle) {
+        const taskPath = await resolveTaskPath(collection, options.pathOrTitle, mapping);
+        const read = await collection.read(taskPath);
+        if (read.error) throw new Error(`Failed to read task: ${read.error.message}`);
+        const frontmatter = normalizeFrontmatter(read.frontmatter as Record<string, unknown>, mapping) as TaskFrontmatter;
+        const active = getActiveTimeEntry({ timeEntries: frontmatter.timeEntries });
+        if (!active) throw new Error("timer_not_found");
+        const plan = buildSpecStopTimeTrackingUpdate({ frontmatter, currentTimestamp: new Date().toISOString(), stopTimestamp: new Date().toISOString(), path: taskPath });
+        const updateResult = await collection.update({ path: taskPath, fields: denormalizeFrontmatter(plan.fields, mapping) });
+        if (updateResult.error) throw new Error(`Failed to stop timer: ${updateResult.error.message}`);
+        showSuccess(`Timer stopped for: ${resolveDisplayTitle(frontmatter, mapping, taskPath) || taskPath}`);
+        return;
+      }
       // Find the task with a running timer
       const result = await collection.query({
         types: ["task"],

--- a/src/commands/timer.ts
+++ b/src/commands/timer.ts
@@ -24,15 +24,13 @@ export async function timerStartCommand(
       const read = await collection.read(taskPath);
 
       if (read.error) {
-        showError(`Failed to read task: ${read.error.message}`);
-        process.exit(1);
+        throw new Error(`Failed to read task: ${read.error.message}`);
       }
 
       const fm = normalizeFrontmatter(read.frontmatter as Record<string, unknown>, mapping);
       const running = getActiveTimeEntry({ timeEntries: fm.timeEntries as TimeEntry[] | undefined });
       if (running) {
-        showError(`Timer already running since ${running.startTime}. Stop it first.`);
-        process.exit(1);
+        throw new Error(`Timer already running since ${running.startTime}. Stop it first.`);
       }
 
       const plan = buildSpecStartTimeTrackingUpdate({
@@ -48,8 +46,7 @@ export async function timerStartCommand(
       });
 
       if (result.error) {
-        showError(`Failed to start timer: ${result.error.message}`);
-        process.exit(1);
+        throw new Error(`Failed to start timer: ${result.error.message}`);
       }
 
       const taskTitle = resolveDisplayTitle(fm, mapping, taskPath) || taskPath;
@@ -57,7 +54,9 @@ export async function timerStartCommand(
     }, options.path);
   } catch (err) {
     showError((err as Error).message);
-    process.exit(1);
+    // process.exit aqui abortava no Windows (UV_HANDLE_CLOSING) porque a colecao
+    // ainda estava fechando; exitCode deixa o loop drenar e sair com 1 de verdade.
+    process.exitCode = 1;
   }
 }
 
@@ -101,8 +100,7 @@ export async function timerStopCommand(
       }
 
       if (!found) {
-        showError("No running timer found.");
-        process.exit(1);
+        throw new Error("No running timer found.");
       }
 
       const { task, entryIndex } = found;
@@ -124,8 +122,7 @@ export async function timerStopCommand(
       });
 
       if (updateResult.error) {
-        showError(`Failed to stop timer: ${updateResult.error.message}`);
-        process.exit(1);
+        throw new Error(`Failed to stop timer: ${updateResult.error.message}`);
       }
 
       const taskTitle = resolveDisplayTitle(task.frontmatter, mapping, task.path) || task.path;
@@ -133,7 +130,9 @@ export async function timerStopCommand(
     }, options.path);
   } catch (err) {
     showError((err as Error).message);
-    process.exit(1);
+    // process.exit aqui abortava no Windows (UV_HANDLE_CLOSING) porque a colecao
+    // ainda estava fechando; exitCode deixa o loop drenar e sair com 1 de verdade.
+    process.exitCode = 1;
   }
 }
 
@@ -172,7 +171,9 @@ export async function timerStatusCommand(
     }, options.path);
   } catch (err) {
     showError((err as Error).message);
-    process.exit(1);
+    // process.exit aqui abortava no Windows (UV_HANDLE_CLOSING) porque a colecao
+    // ainda estava fechando; exitCode deixa o loop drenar e sair com 1 de verdade.
+    process.exitCode = 1;
   }
 }
 
@@ -264,6 +265,8 @@ export async function timerLogCommand(
     }, options.path);
   } catch (err) {
     showError((err as Error).message);
-    process.exit(1);
+    // process.exit aqui abortava no Windows (UV_HANDLE_CLOSING) porque a colecao
+    // ainda estava fechando; exitCode deixa o loop drenar e sair com 1 de verdade.
+    process.exitCode = 1;
   }
 }

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -24,8 +24,7 @@ export async function updateCommand(
       const read = await collection.read(taskPath);
 
       if (read.error) {
-        showError(`Failed to read task: ${read.error.message}`);
-        process.exit(1);
+        throw new Error(`Failed to read task: ${read.error.message}`);
       }
 
       const fm = normalizeFrontmatter(read.frontmatter as Record<string, unknown>, mapping);
@@ -78,8 +77,7 @@ export async function updateCommand(
       }
 
       if (Object.keys(fields).length === 0) {
-        showError("No fields to update. Use flags like --status, --priority, --due, etc.");
-        process.exit(1);
+        throw new Error("No fields to update. Use flags like --status, --priority, --due, etc.");
       }
 
       const result = await collection.update({
@@ -88,14 +86,13 @@ export async function updateCommand(
       });
 
       if (result.error) {
-        showError(`Failed to update task: ${result.error.message}`);
-        process.exit(1);
+        throw new Error(`Failed to update task: ${result.error.message}`);
       }
 
       showSuccess(`Updated: ${taskTitle}`);
     }, options.path);
   } catch (err) {
     showError((err as Error).message);
-    process.exit(1);
+    process.exitCode = 1;
   }
 }

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -15,6 +15,7 @@ export async function updateCommand(
     removeTag?: string[];
     addContext?: string[];
     removeContext?: string[];
+    set?: string[];
   },
 ): Promise<void> {
   try {
@@ -36,6 +37,17 @@ export async function updateCommand(
       if (options.due) fields.due = options.due;
       if (options.scheduled) fields.scheduled = options.scheduled;
       if (options.title) fields.title = options.title;
+
+      for (const assignment of options.set ?? []) {
+        const separator = assignment.indexOf("=");
+        if (separator <= 0) throw new Error("invalid_set_assignment");
+        const field = assignment.slice(0, separator).trim();
+        const value = assignment.slice(separator + 1);
+        if (!field || !(field in (read.frontmatter as Record<string, unknown>))) {
+          throw new Error(`unknown_field:${field}`);
+        }
+        fields[field] = value;
+      }
 
       // Handle tag modifications
       if (options.addTag || options.removeTag) {

--- a/tests/agent-safe-extensions.test.mjs
+++ b/tests/agent-safe-extensions.test.mjs
@@ -1,0 +1,102 @@
+// Extensoes que o adaptador de agentes da Madame Labs exige do mtn: parar o
+// timer de uma tarefa exata sem tocar nas irmas, e escrever user field somente
+// quando ele ja existe no frontmatter. Sao o Gate B do plano de cutover.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { runCli, makeTempDir, stripAnsi } from "./helpers.mjs";
+
+function collectionWithTasks(prefix, titles) {
+  const collectionPath = makeTempDir(prefix);
+  assert.equal(runCli(["init", collectionPath]).status, 0);
+  for (const title of titles) {
+    assert.equal(runCli(["create", title, "--path", collectionPath]).status, 0);
+  }
+  return collectionPath;
+}
+
+const taskFile = (collectionPath, title) =>
+  readFileSync(join(collectionPath, "tasks", `${title}.md`), "utf8");
+
+const runningEntries = (body) =>
+  body.split("\n").filter((line) => line.includes("startTime")).length -
+  body.split("\n").filter((line) => line.includes("endTime")).length;
+
+test("timer stop with an exact path leaves every sibling timer running", () => {
+  const path = collectionWithTasks("mtn-agent-stop-", ["Alvo", "Irma"]);
+  assert.equal(runCli(["timer", "start", "tasks/Alvo.md", "--path", path]).status, 0);
+  assert.equal(runCli(["timer", "start", "tasks/Irma.md", "--path", path]).status, 0);
+
+  const stopped = runCli(["timer", "stop", "tasks/Alvo.md", "--path", path]);
+  assert.equal(stopped.status, 0);
+  assert.match(stripAnsi(stopped.stdout), /Alvo/);
+
+  assert.equal(runningEntries(taskFile(path, "Alvo")), 0);
+  assert.equal(runningEntries(taskFile(path, "Irma")), 1);
+
+  const status = stripAnsi(runCli(["timer", "status", "--path", path]).stdout);
+  assert.match(status, /Irma/);
+  assert.doesNotMatch(status, /Alvo/);
+});
+
+test("timer stop refuses an exact task that has no running timer", () => {
+  const path = collectionWithTasks("mtn-agent-idle-", ["Parada", "Ativa"]);
+  assert.equal(runCli(["timer", "start", "tasks/Ativa.md", "--path", path]).status, 0);
+
+  const refused = runCli(["timer", "stop", "tasks/Parada.md", "--path", path]);
+  assert.equal(refused.status, 1);
+  assert.match(stripAnsi(refused.stdout + refused.stderr), /timer_not_found/);
+
+  // A recusa nao pode virar parada global: a irma segue cronometrando.
+  assert.equal(runningEntries(taskFile(path, "Ativa")), 1);
+});
+
+test("timer stop refuses an unknown path without stopping anything", () => {
+  const path = collectionWithTasks("mtn-agent-ghost-", ["Ativa"]);
+  assert.equal(runCli(["timer", "start", "tasks/Ativa.md", "--path", path]).status, 0);
+
+  const refused = runCli(["timer", "stop", "tasks/Fantasma.md", "--path", path]);
+  assert.equal(refused.status, 1);
+  assert.equal(runningEntries(taskFile(path, "Ativa")), 1);
+});
+
+test("update --set writes a field that already exists in the frontmatter", () => {
+  const path = collectionWithTasks("mtn-agent-set-", ["Campo"]);
+  const applied = runCli(["update", "tasks/Campo.md", "--set", "status=em-andamento", "--path", path]);
+  assert.equal(applied.status, 0);
+  assert.match(taskFile(path, "Campo"), /status: em-andamento/);
+});
+
+test("update --set refuses a field absent from the frontmatter", () => {
+  const path = collectionWithTasks("mtn-agent-unknown-", ["Campo"]);
+  const before = taskFile(path, "Campo");
+
+  const refused = runCli(["update", "tasks/Campo.md", "--set", "Responsavel=[[Arthur_Cardoso]]", "--path", path]);
+  assert.equal(refused.status, 1);
+  assert.match(stripAnsi(refused.stdout + refused.stderr), /unknown_field:Responsavel/);
+  assert.equal(taskFile(path, "Campo"), before);
+});
+
+test("update --set refuses an assignment without a field name", () => {
+  const path = collectionWithTasks("mtn-agent-badset-", ["Campo"]);
+  const before = taskFile(path, "Campo");
+
+  const refused = runCli(["update", "tasks/Campo.md", "--set", "=solto", "--path", path]);
+  assert.equal(refused.status, 1);
+  assert.match(stripAnsi(refused.stdout + refused.stderr), /invalid_set_assignment/);
+  assert.equal(taskFile(path, "Campo"), before);
+});
+
+test("failures exit with 1 instead of aborting the process on Windows", () => {
+  // process.exit durante o fechamento da colecao abortava com 0xC0000409 e
+  // escondia o codigo real de saida de todo caminho de erro.
+  const path = collectionWithTasks("mtn-agent-exit-", ["Campo"]);
+  for (const args of [
+    ["update", "tasks/Inexistente.md", "--status", "open", "--path", path],
+    ["update", "tasks/Campo.md", "--path", path],
+    ["timer", "stop", "tasks/Campo.md", "--path", path],
+  ]) {
+    assert.equal(runCli(args).status, 1, `esperado exit 1 em: ${args.join(" ")}`);
+  }
+});

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -1,7 +1,11 @@
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, readFileSync } from 'node:fs';
+import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Absoluto: os testes rodam com cwd na colecao temporaria, onde dist/ nao existe.
+const CLI = fileURLToPath(new URL('../dist/cli.js', import.meta.url));
 
 const ANSI_RE = /\u001b\[[0-9;]*m/g;
 
@@ -14,13 +18,10 @@ export function stripAnsi(text) {
 }
 
 export function runCli(args, opts = {}) {
-  const runDir = makeTempDir('mtn-run-');
-  const stdoutPath = join(runDir, 'stdout.txt');
-  const stderrPath = join(runDir, 'stderr.txt');
-  const shellArgs = args.map(shellQuote).join(' ');
-  const command = `node dist/cli.js ${shellArgs} > ${shellQuote(stdoutPath)} 2> ${shellQuote(stderrPath)}`;
-
-  const result = spawnSync('bash', ['-lc', command], {
+  // Antes isto passava por `bash -lc` com redirecionamento: no Windows os
+  // caminhos com barra invertida viravam nomes literais e o teste criava
+  // diretorios de lixo dentro do repositorio. spawnSync direto e portavel.
+  const result = spawnSync(process.execPath, [CLI, ...args.map(String)], {
     cwd: opts.cwd,
     encoding: 'utf8',
     env: { ...process.env, ...(opts.env || {}) },
@@ -28,11 +29,7 @@ export function runCli(args, opts = {}) {
 
   return {
     status: result.status,
-    stdout: readFileSync(stdoutPath, 'utf8'),
-    stderr: readFileSync(stderrPath, 'utf8'),
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
   };
-}
-
-function shellQuote(value) {
-  return `'${String(value).replace(/'/g, `'\\''`)}'`;
 }


### PR DESCRIPTION
Three related changes, split into commits that can be taken independently.

### `mtn timer stop <task>` (5ca3825)

`timer stop` only stopped whatever timer happened to be running. With more than one timer active, an automation that means "stop mine" could stop someone else's. The command now accepts an optional task reference and stops exactly that one, leaving siblings running. With no argument the old behaviour is unchanged.

### `mtn update --set field=value` (2f16a87)

There was no way to set a field that has no dedicated flag. `--set` is repeatable and refuses a field that is not already present in the task's frontmatter (`unknown_field:<name>`), so it can't silently invent keys.

### Error paths aborted on Windows instead of exiting 1 (f78b315)

Every command that opens a collection ended its error paths with `process.exit(1)`. On Windows that runs while libuv is still closing the collection handle, so the process aborts with `UV_HANDLE_CLOSING` and exit code `0xC0000409` instead of 1.

This is not specific to the commands above — it affects `create`, `update`, `timer`, `delete` and others, and it made two of this repository's own `create-compat` tests fail on Windows, since they assert `status === 1`.

Errors raised inside a `withCollection` callback now throw so the existing outer `catch` reports them, and that `catch` sets `process.exitCode` instead of exiting mid-teardown. Guards that run before the collection is opened, and the REPL's `exit(0)`, are unchanged.

### Tests (e588710)

`runCli` shelled out to `bash -lc` with redirection. On Windows the backslashes in the redirect targets were taken literally, so every run wrote its capture files into the repository instead of the temp directory. It now spawns node directly and reads stdout/stderr from the child, using an absolute path to the CLI because tests run with cwd inside the temp collection.

`tests/agent-safe-extensions.test.mjs` covers the two new behaviours: sibling timers keep running, an idle or unknown task is refused without stopping anything, `--set` writes an existing field and refuses an absent one without altering the file, and every failure exits with 1.

Full suite on Windows: 1048 passing, 0 failing (was 1039/2 before the exit fix).
